### PR TITLE
Support Rails 8, drop Ruby < 3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,8 @@ AllCops:
   TargetRubyVersion: '3.2'
 Layout/ArgumentAlignment:
   Enabled: false
+
+# Causing rubocop to crash. Maybe related to similar bug in different cop.
+# https://github.com/rubocop/rubocop-rspec/pull/1000
+Style/BitwisePredicate:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,6 @@ AllCops:
     - bin/rails
     - comparison.gemspec
   NewCops: enable
-  TargetRubyVersion: 2.7.0
+  TargetRubyVersion: '3.2'
 Layout/ArgumentAlignment:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 begin
   require 'bundler/setup'

--- a/app/helpers/comparison/application_helper.rb
+++ b/app/helpers/comparison/application_helper.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 module Comparison
   module ApplicationHelper # :nodoc:

--- a/comparison.gemspec
+++ b/comparison.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 3.2'
 
-  s.add_dependency 'rails', '>= 5.0', '< 8.0'
+  s.add_dependency 'rails', '>= 5.0', '< 8.1'
 
   s.add_development_dependency 'mocha'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'debug'
   s.add_development_dependency 'rubocop'
 end

--- a/comparison.gemspec
+++ b/comparison.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.2'
 
-  s.add_dependency 'rails', '>= 5.0', '< 8.1'
+  s.add_dependency 'rails', '>= 5.0', '< 9.0'
 
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'debug'

--- a/comparison.gemspec
+++ b/comparison.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'debug'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'minitest-focus'
 end

--- a/lib/comparison.rb
+++ b/lib/comparison.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'comparison/engine'
 require 'comparison/comparator'

--- a/lib/comparison/comparator.rb
+++ b/lib/comparison/comparator.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'bigdecimal'
 require 'forwardable'

--- a/lib/comparison/engine.rb
+++ b/lib/comparison/engine.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 module Comparison
   class Engine < ::Rails::Engine # :nodoc:

--- a/lib/comparison/presenter.rb
+++ b/lib/comparison/presenter.rb
@@ -13,11 +13,11 @@ module Comparison
 
     ##
     # Returns Comparator#difference formatted as currency.
-    def difference_as_currency(**options)
+    def difference_as_currency(**)
       if positive?
-        number_to_currency __getobj__.difference, format: '+%u%n', **options
+        number_to_currency(__getobj__.difference, format: '+%u%n', **)
       else
-        number_to_currency __getobj__.difference, **options
+        number_to_currency(__getobj__.difference, **)
       end
     end
 
@@ -42,15 +42,15 @@ module Comparison
     # returned.
     #
     # If the change evaluates to NaN, it is returned as 0.
-    def percentage(**options)
+    def percentage(**)
       if nan? || zero?
-        number_to_percentage 0, **options
+        number_to_percentage(0, **)
       elsif infinite?
         t 'comparison.infinity_html', default: nil
       elsif positive?
-        number_to_percentage __getobj__.percentage, format: '+%n%', **options
+        number_to_percentage(__getobj__.percentage, format: '+%n%', **)
       else
-        number_to_percentage __getobj__.percentage, **options
+        number_to_percentage(__getobj__.percentage, **)
       end
     end
 
@@ -61,10 +61,10 @@ module Comparison
     #
     # Use this if you are relying on other cues (colors and/or icons) to
     # indicate positive or negative values.
-    def unsigned_percentage(**options)
-      return percentage(**options) if nan? || infinite?
+    def unsigned_percentage(**)
+      return percentage(**) if nan? || infinite?
 
-      number_to_percentage __getobj__.percentage.abs, **options
+      number_to_percentage(__getobj__.percentage.abs, **)
     end
 
     ##
@@ -219,8 +219,8 @@ module Comparison
       ActiveSupport::NumberHelper.number_to_percentage value, options
     end
 
-    def number_to_currency(*args)
-      ActiveSupport::NumberHelper.number_to_currency(*args)
+    def number_to_currency(*)
+      ActiveSupport::NumberHelper.number_to_currency(*)
     end
 
     def expand_i18n_keys(names, suffix: nil)

--- a/lib/comparison/presenter.rb
+++ b/lib/comparison/presenter.rb
@@ -27,8 +27,10 @@ module Comparison
     # In a future release, this method will be changed to delegate directly
     # `Comparator#difference`.
     def difference(...)
-      Kernel.warn 'DEPRECATION WARNING: use #difference_as_currency instead of #difference' \
-                  " (called from #{caller(3..3).first})"
+      Kernel.warn(<<~MSG.squish)
+        DEPRECATION WARNING: use #difference_as_currency instead of #difference
+        (called from #{caller(3..3).first})
+      MSG
       difference_as_currency(...)
     end
 

--- a/lib/comparison/presenter.rb
+++ b/lib/comparison/presenter.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'delegate'
 

--- a/lib/comparison/version.rb
+++ b/lib/comparison/version.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 module Comparison
   VERSION = '0.2.1'

--- a/test/helpers/comparison/application_helper_test.rb
+++ b/test/helpers/comparison/application_helper_test.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/test/integration/smoke_test.rb
+++ b/test/integration/smoke_test.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/test/lib/comparison/comparator_test.rb
+++ b/test/lib/comparison/comparator_test.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/test/lib/comparison/presenter_test.rb
+++ b/test/lib/comparison/presenter_test.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# frozen-string-literal: true
+# frozen_string_literal: true
 
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,8 +6,9 @@ ENV['RAILS_ENV'] = 'test'
 require_relative '../test/dummy/config/environment'
 require 'rails/test_help'
 
+require 'debug'
+require 'minitest/focus'
 require 'mocha/minitest'
-require 'pry'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries
 # to be shown.


### PR DESCRIPTION
Dropping support for Ruby < 3.2. Opening up support for Rails 8. General cleanup.